### PR TITLE
Whitelist ssh-rsa in renew script

### DIFF
--- a/ui/src/app/info/renew-script/renew-script.component.html
+++ b/ui/src/app/info/renew-script/renew-script.component.html
@@ -46,6 +46,7 @@ chmod 600 /tmp/webos_privkey_{{device.name}}
 <![CDATA[sessionToken=$(ssh -i /tmp/webos_privkey_{{device.name}} \
  -o ConnectTimeout=3 -o StrictHostKeyChecking=no \
  -o HostKeyAlgorithms=+ssh-rsa \
+ -o PubkeyAcceptedKeyTypes=+ssh-rsa \
  -p {{device.port}} {{device.username}}@{{device.host}} \
  cat /var/luna/preferences/devmode_enabled)
 if [ -z "$sessionToken" ]; then

--- a/ui/src/app/info/renew-script/renew-script.component.html
+++ b/ui/src/app/info/renew-script/renew-script.component.html
@@ -45,6 +45,7 @@ chmod 600 /tmp/webos_privkey_{{device.name}}
 ]]></ng-container>
 <![CDATA[sessionToken=$(ssh -i /tmp/webos_privkey_{{device.name}} \
  -o ConnectTimeout=3 -o StrictHostKeyChecking=no \
+ -o HostKeyAlgorithms=+ssh-rsa \
  -p {{device.port}} {{device.username}}@{{device.host}} \
  cat /var/luna/preferences/devmode_enabled)
 if [ -z "$sessionToken" ]; then


### PR DESCRIPTION
# Description

`ssh-rsa` is disabled by default on systems with OpenSSH 8.8 or newer (see
https://www.openssh.com/txt/release-8.8)

Thus the script that is generated will not work without modification (at least in my case with a WebOS 4.0 TV from 2019):
```sh
>./lgtv-renew-devmode.sh
Unable to negotiate with 192.168.8.109 port 9922: no matching host key type found. Their offer: ssh-rsa
cat: /tmp/webos_devmode_token_living-room-TV.txt: No such file or directory
Unable to get token
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have run tests (npm run test & npm run e2e) that prove my fix is effective or that my feature works
