### PR TITLE
Fix typo in renew-script.sh

### DIFF
--- a/src/app/info/renew-script/renew-script.sh
+++ b/src/app/info/renew-script/renew-script.sh
@@ -40,6 +40,6 @@ if [ -z "$SESSION_TOKEN" ]; then
   exit 1
 fi
 
-CHECK_RESULT=$(curl --max-time 3 -s "https://developer.lge.com/secure/ResetDevModeSession.dev?SESSION_TOKEN=$SESSION_TOKEN")
+CHECK_RESULT=$(curl --max-time 3 -s "https://developer.lge.com/secure/ResetDevModeSession.dev?sessionToken=$SESSION_TOKEN")
 
 echo "${CHECK_RESULT}"


### PR DESCRIPTION
# Description

Fixes typo in [src/app/info/renew-script/renew-script.sh](https://github.com/webosbrew/dev-manager-desktop/compare/main...klamike:main#diff-8a97afe2cf0a43c85c1c0e3062a3c1c0abfc499805f85f6e8d193b688340beaf).

Fixes #139 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have run tests (npm run test & npm run e2e) that prove my fix is effective or that my feature works
