### PR TITLE
fix version query on old webOS

### DIFF
--- a/src/app/core/services/device-manager.service.ts
+++ b/src/app/core/services/device-manager.service.ts
@@ -111,7 +111,7 @@ export class DeviceManagerService extends BackendClient {
         const systemInfo = await this.luna.call<SystemInfo>(device, 'luna://com.webos.service.tv.systemproperty/getSystemInfo', {
             keys: ['firmwareVersion', 'modelName', 'sdkVersion', 'otaId']
         });
-        const osInfo = await this.luna.call<Partial<OsInfo>>(device, 'luna://com.webos.service.systemservice/osInfo/query', {
+        const osInfo = await this.luna.call<Partial<OsInfo>>(device, 'luna://com.palm.systemservice/osInfo/query', {
             parameters: ['webos_manufacturing_version', 'webos_release']
         }).catch(() => null);
         return {


### PR DESCRIPTION
# Description

On webOS 1, `com.webos.service.systemservice` doesn't exist. Instead it is named `com.palm.systemservice`. This alias still exists on webOS 8.

Presumably the existing code would not work on webOS 1.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have run tests (npm run test & npm run e2e) that prove my fix is effective or that my feature works

webOS 1:
```
# luna-send-pub -n 1 'luna://com.palm.systemservice/osInfo/query' '{"parameters":["webos_manufacturing_version","webos_release"]}'
{ "webos_manufacturing_version": "05.05.70", "webos_release": "1.4.0", "returnValue": true }
```

webOS 8:
```
# luna-send-pub -n 1 'luna://com.palm.systemservice/osInfo/query' '{"parameters":["webos_manufacturing_version","webos_release"]}'
{"webos_release":"8.1.0","returnValue":true,"webos_manufacturing_version":"03.11.10"}
```