### PR TITLE
Address race condition in renew-script.sh

### DIFF
--- a/src/app/info/renew-script/renew-script.sh
+++ b/src/app/info/renew-script/renew-script.sh
@@ -6,7 +6,15 @@ DEVICE_PORT='{{device.port}}'
 DEVICE_USERNAME='{{device.username}}'
 DEVICE_PASSPHRASE='{{device.passphrase}}'
 
-PRIV_KEY_FILE="/tmp/webos_privkey_${DEVICE_NAME}"
+if ! TEMP_KEY_DIR="$(mktemp -d)"; then
+    echo "Failed to create random temporary directory for key; using fallback" >&2
+    TEMP_KEY_DIR="/tmp/renew-script.$$"
+    mkdir -p "${TEMP_KEY_DIR}"
+fi
+
+chmod 700 "${TEMP_KEY_DIR}"
+
+PRIV_KEY_FILE="${TEMP_KEY_DIR}/webos_privkey_${DEVICE_NAME}"
 
 cat >"${PRIV_KEY_FILE}" <<END_OF_PRIVKEY
 {{keyContent}}
@@ -24,6 +32,8 @@ SESSION_TOKEN=$(ssh -i "${PRIV_KEY_FILE}" \
   -o PubkeyAcceptedKeyTypes=+ssh-rsa \
   -p "${DEVICE_PORT}" "${DEVICE_USERNAME}@${DEVICE_HOST}" \
   cat /var/luna/preferences/devmode_enabled)
+
+rm -rf "${TEMP_KEY_DIR}"
 
 SESSION_TOKEN_CACHE="/tmp/webos_devmode_token_${DEVICE_NAME}.txt"
 


### PR DESCRIPTION
# Description

There is currently a race condition in `renew-script.sh` that could lead to exposure of the SSH private key. This change should resolve the issue by using `mktemp` to create a temporary directory with an unpredictable name and mode 0700.

The temporary directory (and therefore private key) will also be removed when no longer needed.

If `mktemp` does not exist or otherwise fails, a fallback directory will be created with a name based on the PID of the script. The mode will still be set to 0700 before the private key file is created. Since the name is predictable, there is a potential issue with symlink-based attacks. Perhaps the fallback should be removed or improved...

Note that the symlink issue is also present with `$SESSION_TOKEN_CACHE`. I'm not sure how to resolve that, since the name needs to be predictable. Checking that it's a regular file would not solve the problem but would at least make such an attack more difficult. However, I could also imagine someone wanting it to be a symlink (e.g., if `/tmp` is volatile and they want to maintain the cache across reboots). Anyway, this should probably be documented (with a warning to never run the script as root).

Fixes #193

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have run tests (npm run test & npm run e2e) that prove my fix is effective or that my feature works

It would be nice to have someone who uses this script test these changes.