### PR TITLE
add new token refresh method

### DIFF
--- a/src/app/info/renew-script/renew-script.component.html
+++ b/src/app/info/renew-script/renew-script.component.html
@@ -63,6 +63,35 @@
           </ul>
         </ng-template>
       </li>
+      <li ngbNavItem="piratevodka">
+        <a class="text-nowrap" ngbNavLink>Pirate Vodka</a>
+        <ng-template ngbNavContent>
+          <div>
+            <ul>
+              <li>
+                Copy your developer mode token:
+                <div class="overflow-auto bg-panel p-2">
+                  <code class="text-nowrap">{{ devMode.token }}</code>
+                </div>
+              </li>
+              <li>
+                Visit <a href="https://lg.pirate.vodka" target="_blank" rel="noopener noreferrer">https://lg.pirate.vodka</a>
+              </li>
+              <li>
+                Paste your token into the provided field and click <b>Add Token</b>.
+              </li>
+            </ul>
+            <p>
+              Once completed, your token will be automatically renewed every 24 hours.
+            </p>
+            <small>
+              See how lg.pirate.vodka works on <a href="https://github.com/LucifersCircle/webOS-Token-Refresh" target="_blank" rel="noopener noreferrer">
+                Github
+              </a>
+            </small>
+          </div>
+        </ng-template>
+      </li>
     </ul>
 
     <div [ngbNavOutlet]="nav" class="flex-fill overflow-hidden"></div>


### PR DESCRIPTION
added https://lg.pirate.vodka to the "Automatic Developer Mode Renewal" section.

# Description
I had a chance to look at the code and found it straightforward to add this feature, so I managed to add it while the baby was napping. There's more information about lg.pirate.vodka in the related issue, but in short, it automatically refreshes tokens for anyone every 24 hours.

I considered adding the ability to submit tokens directly from within the app, but to keep things lightweight and avoid unnecessary bloat, I decided against it for now. If you'd like that functionality, let me know, it's just a couple of curl requests to implement!

Fixes # [(271) https://github.com/webosbrew/dev-manager-desktop/issues/271#issue-2725588200](https://github.com/webosbrew/dev-manager-desktop/issues/271)
Github: https://github.com/LucifersCircle/webOS-Token-Refresh

## Type of change


- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have run tests that prove my fix is effective or that my feature works

# Screenshot

![Screenshot_9-12-2024_11311_tauri localhost](https://github.com/user-attachments/assets/db6c2678-8310-4757-a537-57d38be447aa)
