### PR TITLE
Set Content-Type on remote-file:// protocol responses

### DIFF
--- a/src-tauri/src/plugins/file.rs
+++ b/src-tauri/src/plugins/file.rs
@@ -252,6 +252,23 @@ pub fn plugin<R: Runtime>(name: &'static str) -> TauriPlugin<R> {
 
 pub const URI_SCHEME: &str = "remote-file";
 
+fn content_type_for_path(path: &str) -> &'static str {
+    let ext = Path::new(path)
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_ascii_lowercase());
+    match ext.as_deref() {
+        Some("png") => "image/png",
+        Some("jpg") | Some("jpeg") => "image/jpeg",
+        Some("gif") => "image/gif",
+        Some("webp") => "image/webp",
+        Some("bmp") => "image/bmp",
+        Some("svg") => "image/svg+xml",
+        Some("ico") => "image/x-icon",
+        _ => "application/octet-stream",
+    }
+}
+
 pub fn protocol<R: Runtime>(
     ctx: UriSchemeContext<'_, R>,
     req: http::Request<Vec<u8>>,
@@ -282,6 +299,7 @@ pub fn protocol<R: Runtime>(
             return;
         };
         let app = app.clone();
+        let content_type = content_type_for_path(&path);
         match tauri::async_runtime::spawn_blocking(move || {
             let sessions = app.state::<SessionManager>();
             return sessions.with_session(device, |session| {
@@ -295,7 +313,13 @@ pub fn protocol<R: Runtime>(
         .await
         {
             Ok(Ok(data)) => {
-                resp.respond(http::Response::builder().status(200).body(data).unwrap());
+                resp.respond(
+                    http::Response::builder()
+                        .status(200)
+                        .header(http::header::CONTENT_TYPE, content_type)
+                        .body(data)
+                        .unwrap(),
+                );
                 return;
             }
             Ok(Err(e)) => {


### PR DESCRIPTION
## Summary
- The `remote-file://` Tauri custom-protocol handler in `src-tauri/src/plugins/file.rs` returned `200 OK` with a body but no `Content-Type` header.
- Modern WebKit-GTK (Linux) and Edge WebView2 (Windows) refuse to render `<img>` resources from custom protocols without a recognised image MIME type, so app icons appeared blank starting around v1.99.16. macOS WKWebView is lenient enough that the regression went unreported there.
- This PR adds a small extension → MIME helper and sets `Content-Type` on the success branch. Only the well-known image extensions used by webOS app icons are mapped; everything else falls back to `application/octet-stream`.

Fixes #400, #334.

## Test plan
- [ ] `cargo check` passes (confirmed locally).
- [ ] Launch on Linux (AppImage) and Windows; verify installed-app icons render in the Apps tab.
- [ ] Confirm macOS still renders icons (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)