### PR TITLE
Respect Android safe-area insets in layout

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,7 @@
   <title>Device Manager for webOS</title>
   <base href="/">
 
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <link rel="icon" type="image/x-icon" href="assets/icons/favicon.ico">
 </head>
 <body>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -22,6 +22,14 @@ html, body {
   overflow: hidden;
 }
 
+body {
+  box-sizing: border-box;
+  padding-top: env(safe-area-inset-top, 0);
+  padding-right: env(safe-area-inset-right, 0);
+  padding-bottom: env(safe-area-inset-bottom, 0);
+  padding-left: env(safe-area-inset-left, 0);
+}
+
 .bg-panel {
   @extend .bg-dark-subtle;
 }


### PR DESCRIPTION
## Summary
- The Tauri Android shell renders edge-to-edge by default, so the app's toolbar slips under the status bar and bottom controls slip under the gesture-nav bar.
- This PR adds `viewport-fit=cover` to the viewport meta and applies `env(safe-area-inset-*)` padding to `body`. On desktop the insets resolve to 0, so this is a no-op there.

Fixes #398.

## Test plan
- [ ] On Android: top toolbar sits below the status bar; bottom controls clear the gesture-nav pill.
- [ ] On desktop (Windows/macOS/Linux): no visible layout change (insets are 0).
- [ ] Verify in landscape (left/right insets on devices with notches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)